### PR TITLE
Patched update

### DIFF
--- a/drs-verify/cmd/server/main.go
+++ b/drs-verify/cmd/server/main.go
@@ -176,15 +176,18 @@ func main() {
 			return
 		}
 
-		// Nonce replay check — before expensive chain verification.
-		if middleware.CheckNonceReplay(w, req.Invocation, nonceStore) {
-			return
-		}
-
 		reqDeps := deps
 		reqDeps.IncludeTimestamps = req.IncludeTimestamps
 
+		// Verify first, commit nonce only on a valid chain. Committing the
+		// nonce from an unsigned payload would let an attacker with a known
+		// JTI pre-consume legitimate nonces by submitting an invalid signature.
 		result := verify.Chain(r.Context(), req.ChainBundle, reqDeps)
+		if result.Valid {
+			if middleware.CheckNonceReplay(w, req.Invocation, nonceStore) {
+				return
+			}
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(result); err != nil {

--- a/drs-verify/pkg/anchor/rfc3161.go
+++ b/drs-verify/pkg/anchor/rfc3161.go
@@ -5,11 +5,14 @@ package anchor
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/subtle"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
+	"hash"
 	"io"
 	"math/big"
 	"net/http"
@@ -39,6 +42,14 @@ var (
 
 	// id-kp-timeStamping from RFC 3161 §2.3
 	oidTimestampingEKU = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+
+	// CMS signed-attribute OIDs per RFC 5652 §11
+	oidContentTypeAttr   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
+	oidMessageDigestAttr = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
+
+	// Digest-only OIDs (used in SignerInfo.DigestAlgorithm)
+	sha384OID = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 2}
+	sha512OID = asn1.ObjectIdentifier{2, 16, 840, 1, 101, 3, 4, 2, 3}
 )
 
 // ── ASN.1 request types ───────────────────────────────────────────────────────
@@ -430,27 +441,163 @@ func extractSignerCert(rawCerts asn1.RawValue, si signerInfo) (*x509.Certificate
 	return nil, fmt.Errorf("no parseable certificate found in SignedData")
 }
 
-// verifySignerInfoSignature verifies the TSA signature in si over tstBytes using cert.
-// When signedAttrs are present (the RFC 3161 standard case), the signature covers
-// the DER-encoded SignedAttributes re-tagged as SET (0x31). When absent, the
-// signature covers the encapsulated content directly.
-func verifySignerInfoSignature(si signerInfo, tstBytes []byte, cert *x509.Certificate) error {
-	var signedContent []byte
-	if len(si.SignedAttrs.FullBytes) > 0 {
-		// Re-tag [0] IMPLICIT (0xa0) to SET (0x31) per RFC 5652 §5.4
-		signedContent = make([]byte, len(si.SignedAttrs.FullBytes))
-		copy(signedContent, si.SignedAttrs.FullBytes)
-		signedContent[0] = 0x31
-	} else {
-		signedContent = tstBytes
-	}
+// cmsAttribute is the CMS Attribute structure per RFC 5652 §5.3.
+// Values is a SET OF AttributeValue — we keep its raw DER bytes for per-attribute parsing.
+type cmsAttribute struct {
+	Type   asn1.ObjectIdentifier
+	Values asn1.RawValue `asn1:"set"`
+}
 
+// verifySignerInfoSignature verifies the TSA signature in si over tstBytes using cert.
+// When SignedAttrs are present (the RFC 3161 standard case), it:
+//  1. Parses SignedAttrs, requires content-type == id-ct-TSTInfo
+//     AND message-digest == Hash(tstBytes) using si.DigestAlgorithm
+//     (without this binding, the signature over SignedAttrs says nothing
+//     about the actual TSTInfo bytes carried in EncapContentInfo)
+//  2. Verifies the signature over DER(SignedAttrs) re-tagged as SET (0x31)
+//
+// When SignedAttrs are absent, the signature covers the encapsulated content directly.
+func verifySignerInfoSignature(si signerInfo, tstBytes []byte, cert *x509.Certificate) error {
 	sigAlgo := mapSignatureAlgorithm(si.SignatureAlgorithm.Algorithm)
 	if sigAlgo == x509.UnknownSignatureAlgorithm {
 		return fmt.Errorf("unsupported TSA signature algorithm: %v", si.SignatureAlgorithm.Algorithm)
 	}
 
+	if len(si.SignedAttrs.FullBytes) == 0 {
+		// No SignedAttrs: signature covers the encapsulated TSTInfo bytes directly.
+		return cert.CheckSignature(sigAlgo, tstBytes, si.Signature)
+	}
+
+	// SignedAttrs present: bind them to TSTInfo before trusting the signature.
+	if err := verifySignedAttrsBinding(si, tstBytes); err != nil {
+		return fmt.Errorf("SignedAttrs binding: %w", err)
+	}
+
+	// Re-tag [0] IMPLICIT (0xa0) to SET (0x31) per RFC 5652 §5.4 so the DER
+	// matches what the signer hashed over SET OF Attribute.
+	signedContent := make([]byte, len(si.SignedAttrs.FullBytes))
+	copy(signedContent, si.SignedAttrs.FullBytes)
+	signedContent[0] = 0x31
 	return cert.CheckSignature(sigAlgo, signedContent, si.Signature)
+}
+
+// verifySignedAttrsBinding parses the SignedAttrs SET OF Attribute and enforces
+// RFC 5652 §11.{1,2}: content-type attribute MUST equal id-ct-TSTInfo, and
+// message-digest attribute MUST equal Hash(tstBytes) under si.DigestAlgorithm.
+func verifySignedAttrsBinding(si signerInfo, tstBytes []byte) error {
+	// si.SignedAttrs.FullBytes begins with [0] IMPLICIT (0xa0). Strip the outer
+	// tag/length to get the SET OF Attribute content, then iterate each Attribute.
+	var outer asn1.RawValue
+	if _, err := asn1.Unmarshal(si.SignedAttrs.FullBytes, &outer); err != nil {
+		return fmt.Errorf("parse SignedAttrs outer tag: %w", err)
+	}
+	attrs, err := parseAttributeSet(outer.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse SignedAttrs: %w", err)
+	}
+
+	var ctSeen, mdSeen bool
+	for _, a := range attrs {
+		switch {
+		case a.Type.Equal(oidContentTypeAttr):
+			if ctSeen {
+				return fmt.Errorf("duplicate content-type attribute")
+			}
+			ctSeen = true
+			if err := checkContentTypeAttr(a.Values); err != nil {
+				return err
+			}
+		case a.Type.Equal(oidMessageDigestAttr):
+			if mdSeen {
+				return fmt.Errorf("duplicate message-digest attribute")
+			}
+			mdSeen = true
+			if err := checkMessageDigestAttr(a.Values, tstBytes, si.DigestAlgorithm.Algorithm); err != nil {
+				return err
+			}
+		}
+	}
+	if !ctSeen {
+		return fmt.Errorf("SignedAttrs missing required content-type attribute")
+	}
+	if !mdSeen {
+		return fmt.Errorf("SignedAttrs missing required message-digest attribute")
+	}
+	return nil
+}
+
+// parseAttributeSet iterates the content bytes of a SET OF Attribute and
+// returns each parsed Attribute. The input is the inner content of the SET
+// (after tag/length), not the outer tag itself.
+func parseAttributeSet(content []byte) ([]cmsAttribute, error) {
+	var out []cmsAttribute
+	rest := content
+	for len(rest) > 0 {
+		var a cmsAttribute
+		var err error
+		rest, err = asn1.Unmarshal(rest, &a)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// checkContentTypeAttr verifies the content-type attribute value is the single
+// OID id-ct-TSTInfo (matching EncapContentInfo.eContentType).
+func checkContentTypeAttr(values asn1.RawValue) error {
+	var oid asn1.ObjectIdentifier
+	rest, err := asn1.Unmarshal(values.Bytes, &oid)
+	if err != nil {
+		return fmt.Errorf("parse content-type attribute value: %w", err)
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("content-type attribute has extra values")
+	}
+	if !oid.Equal(oidTSTInfo) {
+		return fmt.Errorf("content-type is %v, want id-ct-TSTInfo", oid)
+	}
+	return nil
+}
+
+// checkMessageDigestAttr verifies the message-digest attribute equals
+// Hash(tstBytes) under digestOID. This is the critical binding: without it,
+// the signature over SignedAttrs tells us nothing about the actual TSTInfo
+// bytes carried in EncapContentInfo.
+func checkMessageDigestAttr(values asn1.RawValue, tstBytes []byte, digestOID asn1.ObjectIdentifier) error {
+	var declared []byte
+	rest, err := asn1.Unmarshal(values.Bytes, &declared)
+	if err != nil {
+		return fmt.Errorf("parse message-digest attribute value: %w", err)
+	}
+	if len(rest) != 0 {
+		return fmt.Errorf("message-digest attribute has extra values")
+	}
+	h, err := hasherFor(digestOID)
+	if err != nil {
+		return err
+	}
+	h.Write(tstBytes)
+	computed := h.Sum(nil)
+	if subtle.ConstantTimeCompare(declared, computed) != 1 {
+		return fmt.Errorf("message-digest does not match Hash(TSTInfo)")
+	}
+	return nil
+}
+
+// hasherFor returns a fresh hash.Hash for the given digest OID.
+// Supported: SHA-256, SHA-384, SHA-512.
+func hasherFor(oid asn1.ObjectIdentifier) (hash.Hash, error) {
+	switch {
+	case oid.Equal(sha256OID):
+		return sha256.New(), nil
+	case oid.Equal(sha384OID):
+		return sha512.New384(), nil
+	case oid.Equal(sha512OID):
+		return sha512.New(), nil
+	}
+	return nil, fmt.Errorf("unsupported digest algorithm: %v", oid)
 }
 
 // mapSignatureAlgorithm maps a signature algorithm OID to the x509 enum value.

--- a/drs-verify/pkg/anchor/rfc3161_verify_test.go
+++ b/drs-verify/pkg/anchor/rfc3161_verify_test.go
@@ -368,3 +368,361 @@ func TestVerifyTimestampTrusted_RejectsHashMismatch(t *testing.T) {
 		t.Fatal("expected error for hash mismatch, got nil")
 	}
 }
+
+// ── SignedAttrs binding tests (RFC 5652 §5.4) ─────────────────────────────────
+
+// tvContentTypeAttr / tvMessageDigestAttr OIDs (RFC 5652 §11)
+var (
+	tvOIDContentTypeAttr   = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 3}
+	tvOIDMessageDigestAttr = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 4}
+)
+
+// tvSignerInfoWithAttrs mirrors the production signerInfo but includes
+// SignedAttrs as a [0] IMPLICIT field.
+type tvSignerInfoWithAttrs struct {
+	Version            int
+	SID                asn1.RawValue
+	DigestAlgorithm    pkix.AlgorithmIdentifier
+	SignedAttrs        asn1.RawValue `asn1:"tag:0"`
+	SignatureAlgorithm pkix.AlgorithmIdentifier
+	Signature          []byte
+}
+
+type tvSignedDataWithAttrs struct {
+	Version          int
+	DigestAlgorithms []pkix.AlgorithmIdentifier `asn1:"set"`
+	EncapContentInfo tvEncapContentInfo
+	Certificates     asn1.RawValue           `asn1:"optional"`
+	SignerInfos      []tvSignerInfoWithAttrs `asn1:"set"`
+}
+
+type tvAttribute struct {
+	Type   asn1.ObjectIdentifier
+	Values asn1.RawValue // FullBytes must be a DER-encoded SET (0x31 …).
+}
+
+// signedAttrsTamper describes how to tamper with a token's SignedAttrs binding.
+type signedAttrsTamper int
+
+const (
+	tamperNone signedAttrsTamper = iota
+	tamperMessageDigest
+	tamperContentType
+	tamperOmitMessageDigest
+	tamperOmitContentType
+	tamperSwapTSTInfo // sign SignedAttrs for TSTInfo_A but embed TSTInfo_B
+)
+
+// buildTimestampRespWithSignedAttrs builds a TimeStampResp DER whose SignerInfo
+// carries a CMS SignedAttrs set. This is the RFC 3161 standard case that
+// buildTestTimestampResp does not cover.
+func buildTimestampRespWithSignedAttrs(t *testing.T, hashForImprint []byte, tamper signedAttrsTamper) []byte {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ecdsa.GenerateKey: %v", err)
+	}
+	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 64))
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "test-tsa"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("ParseCertificate: %v", err)
+	}
+
+	// Build the real TSTInfo.
+	tstInfoDER, err := asn1.Marshal(tvTSTInfo{
+		Version: 1,
+		Policy:  tvDummyPolicy,
+		MessageImprint: tvMessageImprint{
+			HashAlgorithm: tvHashAlgorithm{Algorithm: tvSHA256OID, Parameters: asn1.NullRawValue},
+			HashedMessage: hashForImprint,
+		},
+		SerialNumber: big.NewInt(42),
+		GenTime:      time.Now().UTC().Truncate(time.Second),
+	})
+	if err != nil {
+		t.Fatalf("marshal TSTInfo: %v", err)
+	}
+
+	// Compute the message-digest attribute value — SHA-256 over the REAL TSTInfo.
+	digestOverReal := sha256.Sum256(tstInfoDER)
+
+	// Build content-type attribute value: SET { OID id-ct-TSTInfo }.
+	ctOID := tvOIDTSTInfo
+	if tamper == tamperContentType {
+		ctOID = asn1.ObjectIdentifier{1, 2, 3, 999} // wrong OID
+	}
+	ctOIDDER, err := asn1.Marshal(ctOID)
+	if err != nil {
+		t.Fatalf("marshal ct OID: %v", err)
+	}
+
+	// Build message-digest attribute value: SET { OCTET STRING digest }.
+	mdBytes := digestOverReal[:]
+	if tamper == tamperMessageDigest {
+		mdBytes = make([]byte, 32) // all zeros — definitely wrong
+	}
+	mdDER, err := asn1.Marshal(mdBytes) // []byte → OCTET STRING
+	if err != nil {
+		t.Fatalf("marshal message-digest: %v", err)
+	}
+
+	// Wrap each attribute's single value in a SET tag: 0x31 len content.
+	ctSetDER, err := asn1.Marshal(asn1.RawValue{
+		Class: asn1.ClassUniversal, Tag: asn1.TagSet, IsCompound: true, Bytes: ctOIDDER,
+	})
+	if err != nil {
+		t.Fatalf("wrap ct as SET: %v", err)
+	}
+	mdSetDER, err := asn1.Marshal(asn1.RawValue{
+		Class: asn1.ClassUniversal, Tag: asn1.TagSet, IsCompound: true, Bytes: mdDER,
+	})
+	if err != nil {
+		t.Fatalf("wrap md as SET: %v", err)
+	}
+
+	var attrs []tvAttribute
+	if tamper != tamperOmitContentType {
+		attrs = append(attrs, tvAttribute{
+			Type:   tvOIDContentTypeAttr,
+			Values: asn1.RawValue{FullBytes: ctSetDER},
+		})
+	}
+	if tamper != tamperOmitMessageDigest {
+		attrs = append(attrs, tvAttribute{
+			Type:   tvOIDMessageDigestAttr,
+			Values: asn1.RawValue{FullBytes: mdSetDER},
+		})
+	}
+
+	// Marshal SignedAttrs as SET OF Attribute (starts with 0x31 SET tag).
+	signedAttrsSetDER, err := asn1.Marshal(struct {
+		Attrs []tvAttribute `asn1:"set"`
+	}{Attrs: attrs})
+	if err != nil {
+		t.Fatalf("marshal signed attrs SET: %v", err)
+	}
+	// asn1.Marshal of a struct wraps in SEQUENCE (0x30). We only want the inner
+	// SET OF Attribute bytes — extract them.
+	var outer asn1.RawValue
+	if _, err := asn1.Unmarshal(signedAttrsSetDER, &outer); err != nil {
+		t.Fatalf("unmarshal outer SEQUENCE: %v", err)
+	}
+	// outer.Bytes contains the SET OF Attribute DER (tag 0x31 …).
+	setOfAttrDER := outer.Bytes
+
+	// signedContent is the DER of the SET — this is what the signer hashes.
+	signingInput := make([]byte, len(setOfAttrDER))
+	copy(signingInput, setOfAttrDER)
+
+	// Sign SHA256(signingInput) with ECDSA.
+	hsi := sha256.Sum256(signingInput)
+	sig, err := ecdsa.SignASN1(rand.Reader, key, hsi[:])
+	if err != nil {
+		t.Fatalf("ecdsa.SignASN1: %v", err)
+	}
+
+	// Build the [0] IMPLICIT tagged SignedAttrs wire form: re-tag 0x31 → 0xa0.
+	implicitTagged := make([]byte, len(setOfAttrDER))
+	copy(implicitTagged, setOfAttrDER)
+	implicitTagged[0] = 0xa0
+
+	sidDER, err := asn1.Marshal(tvIssuerAndSerial{
+		Issuer:       asn1.RawValue{FullBytes: cert.RawIssuer},
+		SerialNumber: cert.SerialNumber,
+	})
+	if err != nil {
+		t.Fatalf("marshal IssuerAndSerial: %v", err)
+	}
+
+	si := tvSignerInfoWithAttrs{
+		Version:            1,
+		SID:                asn1.RawValue{FullBytes: sidDER},
+		DigestAlgorithm:    pkix.AlgorithmIdentifier{Algorithm: tvSHA256OID},
+		SignedAttrs:        asn1.RawValue{FullBytes: implicitTagged},
+		SignatureAlgorithm: pkix.AlgorithmIdentifier{Algorithm: tvOIDECDSAWithSHA256},
+		Signature:          sig,
+	}
+
+	// Optionally swap the embedded TSTInfo AFTER the signature is computed.
+	// This simulates the real attack: a valid TSA signature is paired with
+	// altered timestamp content. The SignedAttrs binding is what catches it.
+	embeddedTSTInfo := tstInfoDER
+	if tamper == tamperSwapTSTInfo {
+		// Build a different TSTInfo (different serial number and imprint).
+		fakeImprint := make([]byte, 32)
+		_, _ = rand.Read(fakeImprint)
+		fakeTSTInfo, err := asn1.Marshal(tvTSTInfo{
+			Version: 1,
+			Policy:  tvDummyPolicy,
+			MessageImprint: tvMessageImprint{
+				HashAlgorithm: tvHashAlgorithm{Algorithm: tvSHA256OID, Parameters: asn1.NullRawValue},
+				HashedMessage: fakeImprint,
+			},
+			SerialNumber: big.NewInt(9999),
+			GenTime:      time.Now().UTC().Truncate(time.Second),
+		})
+		if err != nil {
+			t.Fatalf("marshal fake TSTInfo: %v", err)
+		}
+		embeddedTSTInfo = fakeTSTInfo
+	}
+
+	certTaggedDER, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassContextSpecific,
+		Tag:        0,
+		IsCompound: true,
+		Bytes:      certDER,
+	})
+	if err != nil {
+		t.Fatalf("marshal cert [0] tagged: %v", err)
+	}
+
+	tstOctetDER, err := asn1.Marshal(embeddedTSTInfo)
+	if err != nil {
+		t.Fatalf("marshal embedded TSTInfo: %v", err)
+	}
+	eContentWrapper, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassContextSpecific,
+		Tag:        0,
+		IsCompound: true,
+		Bytes:      tstOctetDER,
+	})
+	if err != nil {
+		t.Fatalf("marshal eContent [0]: %v", err)
+	}
+
+	sd := tvSignedDataWithAttrs{
+		Version:          3,
+		DigestAlgorithms: []pkix.AlgorithmIdentifier{{Algorithm: tvSHA256OID}},
+		EncapContentInfo: tvEncapContentInfo{
+			EContentType: tvOIDTSTInfo,
+			EContent:     asn1.RawValue{FullBytes: eContentWrapper},
+		},
+		Certificates: asn1.RawValue{FullBytes: certTaggedDER},
+		SignerInfos:  []tvSignerInfoWithAttrs{si},
+	}
+	sdDER, err := asn1.Marshal(sd)
+	if err != nil {
+		t.Fatalf("marshal SignedData: %v", err)
+	}
+
+	explicitWrapper, err := asn1.Marshal(asn1.RawValue{
+		Class:      asn1.ClassContextSpecific,
+		Tag:        0,
+		IsCompound: true,
+		Bytes:      sdDER,
+	})
+	if err != nil {
+		t.Fatalf("marshal [0] explicit: %v", err)
+	}
+	ci := tvContentInfo{
+		ContentType: tvOIDSignedData,
+		Content:     asn1.RawValue{FullBytes: explicitWrapper},
+	}
+	ciDER, err := asn1.Marshal(ci)
+	if err != nil {
+		t.Fatalf("marshal ContentInfo: %v", err)
+	}
+
+	resp := tvTimeStampResp{
+		Status:         tvPKIStatusInfo{Status: 0},
+		TimeStampToken: asn1.RawValue{FullBytes: ciDER},
+	}
+	respDER, err := asn1.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal TimeStampResp: %v", err)
+	}
+	return respDER
+}
+
+func TestVerifyTimestamp_SignedAttrs_Valid(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperNone)
+
+	ts, err := anchor.VerifyTimestamp(der, hash)
+	if err != nil {
+		t.Fatalf("valid SignedAttrs token must verify, got: %v", err)
+	}
+	if ts.IsZero() {
+		t.Error("returned zero time")
+	}
+}
+
+func TestVerifyTimestamp_SignedAttrs_TamperedMessageDigest(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperMessageDigest)
+
+	_, err := anchor.VerifyTimestamp(der, hash)
+	if err == nil {
+		t.Fatal("tampered message-digest must be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "message-digest") {
+		t.Errorf("error should mention message-digest, got: %v", err)
+	}
+}
+
+func TestVerifyTimestamp_SignedAttrs_TamperedContentType(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperContentType)
+
+	_, err := anchor.VerifyTimestamp(der, hash)
+	if err == nil {
+		t.Fatal("wrong content-type must be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "content-type") {
+		t.Errorf("error should mention content-type, got: %v", err)
+	}
+}
+
+func TestVerifyTimestamp_SignedAttrs_MissingMessageDigest(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperOmitMessageDigest)
+
+	_, err := anchor.VerifyTimestamp(der, hash)
+	if err == nil {
+		t.Fatal("missing message-digest attr must be rejected, got nil")
+	}
+}
+
+func TestVerifyTimestamp_SignedAttrs_MissingContentType(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperOmitContentType)
+
+	_, err := anchor.VerifyTimestamp(der, hash)
+	if err == nil {
+		t.Fatal("missing content-type attr must be rejected, got nil")
+	}
+}
+
+// TestVerifyTimestamp_SignedAttrs_SwappedTSTInfo is the direct proof that
+// SignedAttrs binding defends against the actual attack: a valid TSA
+// signature over SignedAttrs for TSTInfo_A is paired with altered
+// TSTInfo_B in EncapContentInfo. Without the message-digest check, the
+// signature verifies and the forgery succeeds.
+func TestVerifyTimestamp_SignedAttrs_SwappedTSTInfo(t *testing.T) {
+	hash := make([]byte, 32)
+	_, _ = rand.Read(hash)
+	der := buildTimestampRespWithSignedAttrs(t, hash, tamperSwapTSTInfo)
+
+	_, err := anchor.VerifyTimestamp(der, hash)
+	if err == nil {
+		t.Fatal("swapped TSTInfo must be rejected, got nil — SignedAttrs binding is broken")
+	}
+}

--- a/drs-verify/pkg/middleware/a2a.go
+++ b/drs-verify/pkg/middleware/a2a.go
@@ -44,16 +44,17 @@ func a2aMiddleware(deps verify.Deps, nonceStore *nonce.Store, next http.Handler,
 			return
 		}
 
-		// Nonce replay check — before expensive chain verification.
-		if CheckNonceReplay(w, bundle.Invocation, nonceStore) {
-			return
-		}
-
+		// Verify first, commit nonce only on a valid signature/chain. Committing
+		// the nonce from an unsigned payload would let an attacker with a known
+		// JTI pre-consume legitimate nonces by submitting an invalid signature.
 		result := verify.Chain(r.Context(), bundle, deps)
 		if !result.Valid {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			_ = json.NewEncoder(w).Encode(result)
+			return
+		}
+		if CheckNonceReplay(w, bundle.Invocation, nonceStore) {
 			return
 		}
 

--- a/drs-verify/pkg/middleware/a2a_test.go
+++ b/drs-verify/pkg/middleware/a2a_test.go
@@ -135,7 +135,8 @@ func TestOptionalA2AMiddlewareReturnsNilContextWhenNoBundleHeader(t *testing.T) 
 	}
 }
 
-func TestA2AMiddlewareReplayReturns409(t *testing.T) {
+func TestA2AMiddlewareInvalidSigDoesNotPreConsumeNonce(t *testing.T) {
+	// See TestMCPMiddlewareInvalidSigDoesNotPreConsumeNonce for rationale.
 	ns := nonce.New(100, time.Hour)
 
 	bundle := types.ChainBundle{
@@ -152,13 +153,19 @@ func TestA2AMiddlewareReplayReturns409(t *testing.T) {
 	req1.Header.Set("X-DRS-Bundle", encodeBundle(t, bundle))
 	rr1 := httptest.NewRecorder()
 	handler.ServeHTTP(rr1, req1)
+	if rr1.Code != http.StatusForbidden {
+		t.Errorf("first request (invalid sig): expected 403, got %d", rr1.Code)
+	}
 
 	req2 := httptest.NewRequest(http.MethodPost, "/a2a/task", nil)
 	req2.Header.Set("X-DRS-Bundle", encodeBundle(t, bundle))
 	rr2 := httptest.NewRecorder()
 	handler.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusForbidden {
+		t.Errorf("second request (invalid sig): expected 403, got %d (nonce pre-consumed on invalid sig)", rr2.Code)
+	}
 
-	if rr2.Code != http.StatusConflict {
-		t.Errorf("expected 409 Conflict on replay, got %d", rr2.Code)
+	if err := ns.Check("inv:a2a-replay"); err != nil {
+		t.Errorf("legitimate JTI was wrongly consumed by invalid-sig request: %v", err)
 	}
 }

--- a/drs-verify/pkg/middleware/decode.go
+++ b/drs-verify/pkg/middleware/decode.go
@@ -37,18 +37,16 @@ func decodeInvocationJTI(jwt string) (string, error) {
 	return p.Jti, nil
 }
 
-// CheckNonceReplay extracts the invocation JTI and checks it against the nonce
+// CheckNonceReplay extracts the invocation JTI and commits it to the nonce
 // store. Writes an error response and returns true if the request should be
 // aborted (replay detected, store exhausted, or missing JTI). Returns false
 // if the request should proceed.
 //
-// Exported so the /verify endpoint in cmd/server/main.go can use the same
-// replay protection as the MCP and A2A middleware.
-//
-// Note: the nonce is consumed before verify.Chain runs. If verification
-// subsequently fails, the JTI cannot be reused — the client must generate a
-// new invocation. This is a deliberate trade-off: rejecting replays before
-// expensive cryptographic verification prevents CPU exhaustion attacks.
+// Call this AFTER verify.Chain has successfully validated the signature and
+// chain. Committing the JTI before signature verification would let an
+// attacker with a known (but not signed-for) JTI pre-consume legitimate
+// nonces by sending invalid-signature requests. The rate limiter, not the
+// nonce store, is the layer that defends against CPU exhaustion.
 func CheckNonceReplay(w http.ResponseWriter, invocationJWT string, ns *nonce.Store) bool {
 	if ns == nil {
 		return false

--- a/drs-verify/pkg/middleware/mcp.go
+++ b/drs-verify/pkg/middleware/mcp.go
@@ -57,16 +57,17 @@ func mcpMiddleware(deps verify.Deps, nonceStore *nonce.Store, next http.Handler,
 			return
 		}
 
-		// Nonce replay check — before expensive chain verification.
-		if CheckNonceReplay(w, bundle.Invocation, nonceStore) {
-			return
-		}
-
+		// Verify first, commit nonce only on a valid signature/chain. Committing
+		// the nonce from an unsigned payload would let an attacker with a known
+		// JTI pre-consume legitimate nonces by submitting an invalid signature.
 		result := verify.Chain(r.Context(), bundle, deps)
 		if !result.Valid {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			_ = json.NewEncoder(w).Encode(result)
+			return
+		}
+		if CheckNonceReplay(w, bundle.Invocation, nonceStore) {
 			return
 		}
 

--- a/drs-verify/pkg/middleware/mcp_test.go
+++ b/drs-verify/pkg/middleware/mcp_test.go
@@ -156,7 +156,11 @@ func fakeJWTWithJTI(t *testing.T, jti string) string {
 	return header + "." + payloadB64 + "." + sig
 }
 
-func TestMCPMiddlewareReplayReturns409(t *testing.T) {
+func TestMCPMiddlewareInvalidSigDoesNotPreConsumeNonce(t *testing.T) {
+	// Regression: committing the nonce before signature verification lets an
+	// attacker with a known JTI pre-consume legitimate nonces via invalid-sig
+	// requests. After the fix, two invalid-sig requests sharing a JTI both
+	// return 403 (verify failed) and the JTI is never committed to the store.
 	ns := nonce.New(100, time.Hour)
 
 	bundle := types.ChainBundle{
@@ -169,20 +173,26 @@ func TestMCPMiddlewareReplayReturns409(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	}))
 
-	// First request — nonce recorded, will likely fail at verify.Chain (bad sigs).
 	req1 := httptest.NewRequest(http.MethodPost, "/mcp/tools/call", nil)
 	req1.Header.Set("X-DRS-Bundle", encodeBundle(t, bundle))
 	rr1 := httptest.NewRecorder()
 	handler.ServeHTTP(rr1, req1)
+	if rr1.Code != http.StatusForbidden {
+		t.Errorf("first request (invalid sig): expected 403, got %d", rr1.Code)
+	}
 
-	// Second request — same bundle, should be caught by nonce store.
 	req2 := httptest.NewRequest(http.MethodPost, "/mcp/tools/call", nil)
 	req2.Header.Set("X-DRS-Bundle", encodeBundle(t, bundle))
 	rr2 := httptest.NewRecorder()
 	handler.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusForbidden {
+		t.Errorf("second request (invalid sig): expected 403, got %d (nonce was pre-consumed on invalid sig)", rr2.Code)
+	}
 
-	if rr2.Code != http.StatusConflict {
-		t.Errorf("expected 409 Conflict on replay, got %d", rr2.Code)
+	// The JTI must NOT have been recorded in the nonce store — a legitimate
+	// future request with this JTI must still be acceptable.
+	if err := ns.Check("inv:replay-test"); err != nil {
+		t.Errorf("legitimate JTI was wrongly consumed by invalid-sig request: %v", err)
 	}
 }
 

--- a/drs-verify/pkg/resolver/did.go
+++ b/drs-verify/pkg/resolver/did.go
@@ -35,6 +35,10 @@ const (
 	multicodecPrefixLen   = 2
 	decodedLen            = multicodecPrefixLen + ed25519PublicKeyBytes
 	didWebFetchTimeout    = 10 * time.Second
+	// maxDIDDocumentBytes caps the DID document body size. A well-formed
+	// did:web document is well under 10 KiB; 1 MiB is a generous upper bound
+	// that still prevents memory-pressure DoS from attacker-controlled hosts.
+	maxDIDDocumentBytes = 1 << 20 // 1 MiB
 )
 
 // cacheEntry holds a resolved public key and its expiry time.
@@ -129,21 +133,81 @@ type inflightEntry struct {
 }
 
 // New creates a Resolver with an LRU cache of the given size and TTL.
-// did:web fetches use a 10-second timeout.
+// did:web fetches use a 10-second timeout, a custom DialContext that rejects
+// private IPs at connect time (closing DNS-rebinding and redirect-to-private
+// SSRF paths), and a redirect policy that forbids redirects entirely.
 func New(cacheSize int, ttl time.Duration) (*Resolver, error) {
 	c, err := lru.New[string, cacheEntry](cacheSize)
 	if err != nil {
 		return nil, fmt.Errorf("resolver: failed to create LRU cache: %w", err)
 	}
-	return &Resolver{
+	r := &Resolver{
 		cache:         c,
 		ttl:           ttl,
-		httpClient:    &http.Client{Timeout: didWebFetchTimeout},
 		inflight:      make(map[string]*inflightEntry),
 		circuitStates: make(map[string]*circuitState),
 		cbThreshold:   5,
 		cbCooldown:    60 * time.Second,
-	}, nil
+	}
+	r.httpClient = &http.Client{
+		Timeout: didWebFetchTimeout,
+		Transport: &http.Transport{
+			DialContext:           r.safeDialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			IdleConnTimeout:       30 * time.Second,
+			MaxIdleConns:          10,
+		},
+		// Forbid redirects: did:web documents are served directly; any redirect
+		// is either misconfiguration or an attempt to bypass the pre-request
+		// hostname check (including redirecting to 169.254.169.254 or similar).
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return fmt.Errorf("did:web: redirects not allowed (to %s)", req.URL.Host)
+		},
+	}
+	return r, nil
+}
+
+// safeDialContext is the http.Transport.DialContext for r.httpClient.
+// It validates every connect attempt (including redirect targets, if they
+// were allowed) against the private-IP blocklist, closing DNS-rebinding and
+// redirect-to-internal SSRF bypasses that pre-request hostname checks miss.
+// Tests set allowPrivateHosts so httptest servers on 127.0.0.1 are reachable.
+func (r *Resolver) safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("safeDial: split host/port %q: %w", addr, err)
+	}
+	d := net.Dialer{Timeout: 5 * time.Second}
+
+	// If addr is already a literal IP, check and dial directly.
+	if ip := net.ParseIP(host); ip != nil {
+		if !r.allowPrivateHosts && isPrivateIP(ip) {
+			return nil, fmt.Errorf("safeDial: refused connection to private address %s", ip)
+		}
+		return d.DialContext(ctx, network, addr)
+	}
+
+	// Resolve host ourselves so the IP we validate is the IP we connect to.
+	// This closes the DNS-rebinding window between pre-check and default-dialer
+	// re-resolution.
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, fmt.Errorf("safeDial: resolve %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("safeDial: no addresses for %q", host)
+	}
+	for _, ia := range ips {
+		if !r.allowPrivateHosts && isPrivateIP(ia.IP) {
+			return nil, fmt.Errorf("safeDial: %q resolves to private address %s", host, ia.IP)
+		}
+	}
+	// Dial the first resolved IP directly. Using the literal IP (not the
+	// hostname) prevents the dialer from re-resolving and reaching a different
+	// address than the one we validated.
+	target := net.JoinHostPort(ips[0].IP.String(), port)
+	return d.DialContext(ctx, network, target)
 }
 
 // NewWithCircuitBreaker creates a Resolver with circuit breaker protection for
@@ -406,10 +470,16 @@ func (r *Resolver) resolveDidWeb(ctx context.Context, did string) ([ed25519Publi
 		return zero, fmt.Errorf("did:web fetch failed: HTTP %d from %s", resp.StatusCode, fetchURL)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	// Cap body size. An attacker-controlled public host could otherwise serve
+	// an arbitrarily large "DID document" and drive memory pressure.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxDIDDocumentBytes+1))
 	if err != nil {
 		cs.recordFailure(r.cbThreshold, r.cbCooldown)
 		return zero, fmt.Errorf("did:web document read failed: %w", err)
+	}
+	if len(body) > maxDIDDocumentBytes {
+		cs.recordFailure(r.cbThreshold, r.cbCooldown)
+		return zero, fmt.Errorf("did:web document exceeds %d byte limit", maxDIDDocumentBytes)
 	}
 
 	key, extractErr := extractEd25519FromDIDDocument(body)

--- a/drs-verify/pkg/resolver/did_test.go
+++ b/drs-verify/pkg/resolver/did_test.go
@@ -501,3 +501,89 @@ func TestCircuitBreakerClosesAfterCooldown(t *testing.T) {
 		t.Errorf("probe after cooldown: expected success, got %v", err)
 	}
 }
+
+func TestResolveDidWeb_RedirectsBlocked(t *testing.T) {
+	// Two servers: target serves a valid doc, redirector returns a 302 to target.
+	// Even though the redirect target is also on 127.0.0.1 (which the test
+	// allows), the CheckRedirect policy must refuse to follow it.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(buildTestDIDDocument(t, r))
+	}))
+	defer target.Close()
+
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+r.URL.Path, http.StatusFound)
+	}))
+	defer redirector.Close()
+
+	host := strings.TrimPrefix(redirector.URL, "http://")
+	did := "did:web:" + strings.ReplaceAll(host, ":", "%3A")
+
+	res, err := New(10, time.Hour)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res.allowPrivateHosts = true
+
+	_, err = res.Resolve(context.Background(), did)
+	if err == nil {
+		t.Fatal("expected redirect to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "redirect") {
+		t.Errorf("error should mention redirect, got: %v", err)
+	}
+}
+
+func TestResolveDidWeb_BodySizeLimit(t *testing.T) {
+	// Serve a body larger than maxDIDDocumentBytes. The fetch must be rejected
+	// without attempting to fully read or parse it.
+	oversize := make([]byte, maxDIDDocumentBytes+128)
+	for i := range oversize {
+		oversize[i] = 'x'
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(oversize)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	did := "did:web:" + strings.ReplaceAll(host, ":", "%3A")
+
+	res, err := New(10, time.Hour)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	res.allowPrivateHosts = true
+
+	_, err = res.Resolve(context.Background(), did)
+	if err == nil {
+		t.Fatal("expected body-size error, got nil")
+	}
+	if !strings.Contains(err.Error(), "byte limit") && !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error should mention size limit, got: %v", err)
+	}
+}
+
+func TestSafeDialContext_RejectsPrivateIP(t *testing.T) {
+	// Direct unit test of safeDialContext without httptest. A public hostname
+	// is not required — we dial an IP literal in a private range.
+	res, err := New(10, time.Hour)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// allowPrivateHosts is false by default — private IP dial must fail.
+	_, err = res.safeDialContext(context.Background(), "tcp", "127.0.0.1:1")
+	if err == nil {
+		t.Fatal("expected refused connection to 127.0.0.1, got nil")
+	}
+	if !strings.Contains(err.Error(), "private") {
+		t.Errorf("error should mention private address, got: %v", err)
+	}
+
+	// Also reject AWS IMDS link-local address literal.
+	_, err = res.safeDialContext(context.Background(), "tcp", "169.254.169.254:80")
+	if err == nil {
+		t.Fatal("expected refused connection to 169.254.169.254, got nil")
+	}
+}

--- a/drs-verify/pkg/revocation/admin_handler.go
+++ b/drs-verify/pkg/revocation/admin_handler.go
@@ -1,6 +1,7 @@
 package revocation
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"log/slog"
@@ -51,9 +52,13 @@ func AdminRevokeHandler(store *LocalRevocationStore, token string) http.Handler 
 			return
 		}
 
-		expected := "Bearer " + token
-		actual := r.Header.Get("Authorization")
-		if subtle.ConstantTimeCompare([]byte(expected), []byte(actual)) != 1 {
+		// Hash both values to a fixed 32-byte SHA-256 digest before comparing.
+		// subtle.ConstantTimeCompare exits early on length mismatch, which
+		// leaks the attacker-supplied token length via timing. Equal-length
+		// hash inputs eliminate that side channel.
+		expectedHash := sha256.Sum256([]byte("Bearer " + token))
+		actualHash := sha256.Sum256([]byte(r.Header.Get("Authorization")))
+		if subtle.ConstantTimeCompare(expectedHash[:], actualHash[:]) != 1 {
 			writeJSON(w, http.StatusUnauthorized, errorResponse{Error: "unauthorized"})
 			return
 		}

--- a/drs-verify/pkg/revocation/admin_handler_test.go
+++ b/drs-verify/pkg/revocation/admin_handler_test.go
@@ -1,6 +1,7 @@
 package revocation
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -235,5 +236,44 @@ func TestAdminRevokeTokenRejection(t *testing.T) {
 				t.Errorf("auth=%q: got status %d, want %d", tc.auth, w.Code, tc.status)
 			}
 		})
+	}
+}
+
+func TestAdminRevokeHandler_HashedCompareAcceptsCorrectToken(t *testing.T) {
+	// Sanity: the SHA-256-based compare accepts the exact expected token.
+	s := NewLocalRevocationStore()
+	h := AdminRevokeHandler(s, "very-long-admin-token-42")
+
+	body := bytes.NewReader([]byte(`{"status_list_index":7}`))
+	req := httptest.NewRequest(http.MethodPost, "/admin/revoke", body)
+	req.Header.Set("Authorization", "Bearer very-long-admin-token-42")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestAdminRevokeHandler_HashedCompareRejectsMismatchedLengths(t *testing.T) {
+	// Inputs of very different lengths must both be rejected and treated
+	// identically: fixed-length hash input removes the length-based early exit.
+	s := NewLocalRevocationStore()
+	h := AdminRevokeHandler(s, "correct-token")
+
+	cases := []string{
+		"",                             // empty
+		"x",                            // 1 char
+		"Bearer c",                     // prefix match of expected
+		"Bearer " + "extremely-long-wrong-token-" + "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	}
+	for _, auth := range cases {
+		body := bytes.NewReader([]byte(`{"status_list_index":0}`))
+		req := httptest.NewRequest(http.MethodPost, "/admin/revoke", body)
+		req.Header.Set("Authorization", auth)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("auth=%q: expected 401, got %d", auth, w.Code)
+		}
 	}
 }

--- a/drs-verify/pkg/revocation/status.go
+++ b/drs-verify/pkg/revocation/status.go
@@ -20,6 +20,12 @@ import (
 	"time"
 )
 
+// fetchTimeout bounds how long a single status list refresh may run.
+// Independent of the caller's context: request cancellation must not abort a
+// cache write that other callers depend on, but refreshes must have their own
+// deadline so a slow status list endpoint cannot hang verifications forever.
+const fetchTimeout = 15 * time.Second
+
 // StatusCache caches a remote Bitstring Status List with TTL-based refresh.
 type StatusCache struct {
 	mu         sync.RWMutex
@@ -44,12 +50,21 @@ func New(baseURL string, ttl time.Duration) *StatusCache {
 // IsRevoked returns true if the credential at the given statusListIndex is revoked.
 // On the first call it fetches the status list (sync.Once prevents double-fetch).
 // On subsequent calls it returns the cached value unless TTL has expired.
+//
+// ctx is honoured for fast-fail on caller cancellation: refreshes themselves
+// use their own context (see fetchTimeout) so a cancelled request cannot poison
+// a shared initialisation or abort a write other callers depend on.
 func (s *StatusCache) IsRevoked(ctx context.Context, statusListIndex uint64) (bool, error) {
+	// Fast-fail on caller cancellation before doing any work.
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	var initErr error
 
 	// First fetch — protected by sync.Once to prevent double-fetch race condition.
-	// Uses context.Background() intentionally: if the first caller's context is
-	// cancelled we must not poison the once guard for all future callers.
+	// Uses a fresh context so the first caller's cancellation cannot poison
+	// the once guard for all future callers.
 	s.once.Do(func() {
 		initErr = s.refresh(context.Background())
 	})
@@ -111,6 +126,7 @@ func (s *StatusCache) WarmUp() error {
 // refresh fetches the current status list from the remote endpoint.
 // Only publishes the new bitstring if the entire body was read successfully.
 // On failure, the previous known-good snapshot (if any) is preserved.
+// Always enforces a fetchTimeout bound on the refresh regardless of ctx.
 func (s *StatusCache) refresh(ctx context.Context) error {
 	if s.baseURL == "" {
 		s.mu.Lock()
@@ -120,7 +136,12 @@ func (s *StatusCache) refresh(ctx context.Context) error {
 		return nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.baseURL, nil)
+	// Bound the refresh even when ctx is context.Background(). Without an
+	// explicit deadline a slow TSA could block TTL-refresh goroutines forever.
+	fetchCtx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(fetchCtx, http.MethodGet, s.baseURL, nil)
 	if err != nil {
 		return fmt.Errorf("building request for %s: %w", s.baseURL, err)
 	}

--- a/drs-verify/pkg/revocation/status_test.go
+++ b/drs-verify/pkg/revocation/status_test.go
@@ -3,6 +3,8 @@ package revocation
 import (
 	"bytes"
 	"context"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -297,5 +299,55 @@ func TestRefreshPreservesSnapshotOnError(t *testing.T) {
 	// Old snapshot had bit 0 set → should still return true.
 	if !revoked {
 		t.Error("expected index 0 to be revoked (from preserved snapshot)")
+	}
+}
+
+func TestIsRevokedReturnsErrorOnCancelledContext(t *testing.T) {
+	// A cancelled context must cause IsRevoked to fail fast — without waiting
+	// for a status-list fetch that would block on the network.
+	c := New("http://127.0.0.1:1/unreachable", time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before calling
+	_, err := c.IsRevoked(ctx, 0)
+	if err == nil {
+		t.Fatal("expected error on cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error should wrap context.Canceled, got: %v", err)
+	}
+}
+
+func TestRefreshHasExplicitFetchTimeout(t *testing.T) {
+	// Serve a connection that accepts the request but never responds. The
+	// refresh must fail via its own fetchTimeout, not the HTTP client timeout
+	// (which would also work but we want the context-level bound to be active).
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer l.Close()
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		// Hold connection open without responding.
+		defer c.Close()
+		buf := make([]byte, 1)
+		_, _ = c.Read(buf)
+		// Then sleep — never send a response.
+		time.Sleep(30 * time.Second)
+	}()
+	start := time.Now()
+	cache := New("http://"+l.Addr().String(), time.Hour)
+	_, err = cache.IsRevoked(context.Background(), 0)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	// The http.Client has Timeout=10s; the context adds fetchTimeout=15s.
+	// Whichever fires first wins — must be within ~20s.
+	if elapsed > 20*time.Second {
+		t.Errorf("refresh did not honour timeout: took %v", elapsed)
 	}
 }

--- a/drs-verify/pkg/store/filesystem.go
+++ b/drs-verify/pkg/store/filesystem.go
@@ -16,9 +16,11 @@ const (
 	dirPermission  = 0o700
 )
 
-// validHashRe matches exactly 64 lowercase hex characters — a SHA-256 digest.
-// Anything else (path separators, dots, uppercase, wrong length) is rejected.
-var validHashRe = regexp.MustCompile(`^[0-9a-f]{64}$`)
+// validKeyRe matches a SHA-256 digest (64 lowercase hex characters) with an
+// optional ".jwt" or ".tst" extension. Anything else is rejected at the
+// path-construction boundary to prevent traversal (../), separators, null
+// bytes, uppercase, wrong length, and unknown extensions.
+var validKeyRe = regexp.MustCompile(`^([0-9a-f]{64})(?:\.(jwt|tst))?$`)
 
 // FilesystemStore is a Tier-1 DR store backed by the local filesystem.
 //
@@ -102,14 +104,22 @@ func (f *FilesystemStore) Delete(hash string) error {
 	return nil
 }
 
-// hashPath maps a chain hash key to an absolute file path.
-// Strips the "sha256:" prefix before using the hex digest as a filename.
-// Returns an error if the hash is not exactly 64 lowercase hex characters.
+// hashPath maps a store key to an absolute file path.
+// Strips the "sha256:" prefix and accepts an optional ".jwt" or ".tst"
+// extension in the key (Tier3Store uses ".tst" for RFC 3161 timestamp tokens).
+// Returns an error for any other shape — this is the path-traversal boundary,
+// so it must be strict and fail-closed.
 func (f *FilesystemStore) hashPath(hash string) (string, error) {
 	name := strings.TrimPrefix(hash, "sha256:")
-	if !validHashRe.MatchString(name) {
-		return "", fmt.Errorf("store: invalid hash %q: must be 64 lowercase hex characters", hash)
+	m := validKeyRe.FindStringSubmatch(name)
+	if m == nil {
+		return "", fmt.Errorf("store: invalid key %q: must be 64 lowercase hex characters with an optional .jwt or .tst extension", hash)
 	}
-	prefix := name[:4]
-	return filepath.Join(f.baseDir, prefix, name+".jwt"), nil
+	digest := m[1]
+	ext := m[2]
+	if ext == "" {
+		ext = "jwt"
+	}
+	prefix := digest[:4]
+	return filepath.Join(f.baseDir, prefix, digest+"."+ext), nil
 }

--- a/drs-verify/pkg/store/store_test.go
+++ b/drs-verify/pkg/store/store_test.go
@@ -195,3 +195,72 @@ func TestFilesystemStoreValidHash(t *testing.T) {
 		t.Errorf("Get returned %q, want %q", got, "test.jwt")
 	}
 }
+
+func TestFilesystemStoreTstExtensionAccepted(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.NewFilesystemStore(dir, 0)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+	// Tier3Store stores RFC 3161 timestamp tokens under hash + ".tst".
+	// The filesystem store must accept this key shape.
+	tstKey := "sha256:" + strings.Repeat("a1", 32) + ".tst"
+	if err := s.Put(tstKey, "token-bytes"); err != nil {
+		t.Fatalf("Put with .tst key: %v", err)
+	}
+	got, err := s.Get(tstKey)
+	if err != nil {
+		t.Fatalf("Get with .tst key: %v", err)
+	}
+	if got != "token-bytes" {
+		t.Errorf("Get returned %q, want %q", got, "token-bytes")
+	}
+	if err := s.Delete(tstKey); err != nil {
+		t.Errorf("Delete with .tst key: %v", err)
+	}
+}
+
+func TestFilesystemStoreJwtAndTstDisjoint(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.NewFilesystemStore(dir, 0)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+	// JWT and TST keys for the same digest must map to distinct files,
+	// so storing a token does not overwrite the receipt.
+	digest := "sha256:" + strings.Repeat("cd", 32)
+	if err := s.Put(digest, "receipt-jwt"); err != nil {
+		t.Fatalf("Put jwt: %v", err)
+	}
+	if err := s.Put(digest+".tst", "timestamp-token"); err != nil {
+		t.Fatalf("Put tst: %v", err)
+	}
+	gotJWT, err := s.Get(digest)
+	if err != nil || gotJWT != "receipt-jwt" {
+		t.Errorf("Get jwt: got %q, err=%v; want %q", gotJWT, err, "receipt-jwt")
+	}
+	gotTST, err := s.Get(digest + ".tst")
+	if err != nil || gotTST != "timestamp-token" {
+		t.Errorf("Get tst: got %q, err=%v; want %q", gotTST, err, "timestamp-token")
+	}
+}
+
+func TestFilesystemStoreRejectsUnknownExtensions(t *testing.T) {
+	dir := t.TempDir()
+	s, err := store.NewFilesystemStore(dir, 0)
+	if err != nil {
+		t.Fatalf("NewFilesystemStore: %v", err)
+	}
+	bad := []string{
+		"sha256:" + strings.Repeat("a1", 32) + ".exe",
+		"sha256:" + strings.Repeat("a1", 32) + ".evil",
+		"sha256:" + strings.Repeat("a1", 32) + ".JWT", // uppercase
+		"sha256:" + strings.Repeat("a1", 32) + ".",
+		"sha256:" + strings.Repeat("a1", 32) + "..tst", // double dot
+	}
+	for _, key := range bad {
+		if err := s.Put(key, "x"); err == nil {
+			t.Errorf("Put(%q) should have returned an error", key)
+		}
+	}
+}


### PR DESCRIPTION
 - **RFC 3161 CMS SignedAttrs binding** : Verify signature binds to TSTInfo via content-type and message-digest attributes  accept `.jwt` and `.tst` extensions                                           
 - **DNS rebinding SSRF**: Custom dialer validates IPs at connect time,  not just pre-request                                                        
  - **Redirect exploitation** : Block all HTTP redirects on did:web fetches 
  - **Revocation fetch timeout** : Independent 15s timeout prevents background refreshes hanging                                                  
  - **Nonce pre-consumption**: Move nonce commit to AFTER signature verification                                                                  
  - **Admin token timing leak**: Hash tokens to fixed-length before constant-time compare   