### PR TITLE
fix(e2e): align integration harness with hardened verifier behavior

### DIFF
--- a/integration-tests/docker-compose.test.yml
+++ b/integration-tests/docker-compose.test.yml
@@ -23,6 +23,11 @@ services:
       LISTEN_ADDR: ":8080"
       LOG_LEVEL: "info"
       LOG_FORMAT: "json"
+      # The verifier is fail-closed on destination binding: an invocation that
+      # names a tool_server is rejected with TOOL_SERVER_MISMATCH unless this
+      # identity matches it. The E2E bundles bind to did:key:z6MkTool, so the
+      # verifier must claim that identity for the happy paths to verify.
+      SERVER_IDENTITY: "did:key:z6MkTool"
       # Exercise the Redis-backed nonce store — this proves cross-replica
       # replay protection would work in production.
       NONCE_STORE_BACKEND: "redis"

--- a/integration-tests/tests/e2e.test.mjs
+++ b/integration-tests/tests/e2e.test.mjs
@@ -16,7 +16,7 @@ import {
   computeChainHash,
   serialiseBundle,
 } from "@okeyamy/drs-sdk";
-import { generateKey, didFromKey, now, postVerify, postVerifyWithBody } from "./util.mjs";
+import { generateKey, didFromKey, now, postVerify, postVerifyWithBody, sleep } from "./util.mjs";
 
 const VERIFY_URL = process.env.DRS_VERIFY_URL ?? "http://localhost:8080";
 // /metrics lives on a separate listener (METRICS_ADDR), mapped to host 19090 by
@@ -78,7 +78,7 @@ describe("happy path — fresh chain verifies", () => {
       cmd: "/mcp/tools/call",
       args: { tool: "echo", message: "hello", estimated_cost_usd: 0.01 },
       drChain: [computeChainHash(rootDR)],
-      toolServer: "did:key:z6MkExampleToolServer",
+      toolServer: "did:key:z6MkTool",
     });
 
     const bundle = buildBundle([rootDR], invocation);
@@ -491,6 +491,11 @@ describe("/admin/revoke — requires DRS_ADMIN_TOKEN", () => {
   });
 
   test("correct token returns 200 and records revocation", async () => {
+    // /admin/revoke has its own deliberately tight limiter (1 req/s per IP,
+    // burst 1). The wrong-token test above consumed this IP's token, so wait
+    // for the bucket to refill before the real request — otherwise we get 429.
+    await sleep(1100);
+
     const res = await fetch(`${VERIFY_URL}/admin/revoke`, {
       method: "POST",
       headers: {

--- a/integration-tests/tests/util.mjs
+++ b/integration-tests/tests/util.mjs
@@ -48,6 +48,11 @@ export function now() {
   return Math.floor(Date.now() / 1000);
 }
 
+/** Resolves after the given number of milliseconds. */
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /** POST /verify and return the parsed JSON body (+ status). */
 export async function postVerify(url, bundle) {
   const res = await fetch(`${url}/verify`, {


### PR DESCRIPTION
## Summary

The E2E test suite was broken after the security hardening PRs (#81, #83) because the test harness predated two now-enforced protections:

1. **Destination binding is fail-closed (F-014)**: An invocation that names a `tool_server` is now rejected with `TOOL_SERVER_MISMATCH` unless the verifier claims a matching `SERVER_IDENTITY`. The compose file set no identity, so every bundle that bound a tool_server failed verification — 6 of 8 test failures across happy path, body binding, middleware, and replay checks.

2. **Admin endpoint rate limiting**: `/admin/revoke` has its own deliberately tight limiter (1 req/s per IP, burst 1) as a non-configurable security default. Back-to-back admin tests tripped it on the second request: 429 instead of 200.

## Changes

- **docker-compose.test.yml**: Set `SERVER_IDENTITY=did:key:z6MkTool` to match test bundle identities
- **e2e.test.mjs**: 
  - Align happy-path `toolServer` DID from placeholder to `did:key:z6MkTool`
  - Add 1.1s delay between admin tests to let rate limiter refill
  - Import `sleep` helper
- **util.mjs**: Add `sleep(ms)` utility

## Test plan

- [x] Full E2E suite runs green: 14/14 tests pass
- [x] E2E via `run.sh` (docker-compose, Redis-backed nonce store) — full cycle working
- [x] No production code changes — test harness only

Production code is unchanged and correct; the harness is updated to align with the stricter post-hardening behavior.